### PR TITLE
Fix error when callr option default is NULL

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -73,7 +73,7 @@ install_process <- R6::R6Class(
     callr_r_bg = function(...) {
       # default formal argument values
       options <- formals(callr::r_bg)
-      options <- options[vlapply(options, `!=`, bquote())]
+      options <- options[vlapply(options, function(x) !identical(x, bquote()))]
       options <- lapply(options, eval, envir = asNamespace("callr"))
 
       # ellipsis arguments


### PR DESCRIPTION
Dev callr (about to be submitted to CRAN) has changed the default value of one of its options to `NULL`. This makes the checked package fail `R CMD check`. This PR fixes that.

`NULL != bquote()` returns `logical(0)` instead of `TRUE`, causing `vapply()` to error. Use `!identical(x, bquote())` which correctly returns a scalar logical for any value including NULL.